### PR TITLE
Bug fix download dataset

### DIFF
--- a/kdap/analysis.py
+++ b/kdap/analysis.py
@@ -566,9 +566,9 @@ class knol(object):
             raise TypeError('download_dataset() requires at least one of article_list, category_list or template_list\
                             arguments to be specified')
 
-        if(kwargs.get('compress') is not None):
-            compress_bool = kwargs.get('compress')
-        else:
+        try:
+            compress_bool = kwargs['compress']
+        except:
             compress_bool = False
 
         sitename = sitename.lower()

--- a/kdap/analysis.py
+++ b/kdap/analysis.py
@@ -562,13 +562,13 @@ class knol(object):
         \*\*final_template_list : list[str]
             A list of wikipedia article names. Only when template_list is provided as argument
         """
-        if sitename != 'stackexchange' and kwargs['article_list'] is None and kwargs['catgory_list'] is None and kwargs['template_list'] is None:
+        if sitename != 'stackexchange' and kwargs.get('article_list') is None and kwargs.get('category_list') is None and kwargs.get('template_list') is None:
             raise TypeError('download_dataset() requires at least one of article_list, category_list or template_list\
                             arguments to be specified')
 
-        try:
-            compress_bool = kwargs['compress']
-        except:
+        if(kwargs.get('compress') is not None):
+            compress_bool = kwargs.get('compress')
+        else:
             compress_bool = False
 
         sitename = sitename.lower()


### PR DESCRIPTION
Following bugs are addressed in this pull request
1. While checking if 'article_list', 'template_list', 'category_list' are provided in kwargs, we were directly accessing these keys and then checking for null. This will result in a KeyError. This is now fixed by using the get function in kwargs.
2. There was a typo in 'catgory_list', which is fixed now. Changed to 'category_list'.